### PR TITLE
Polish translation support

### DIFF
--- a/lib/refinery/i18n.rb
+++ b/lib/refinery/i18n.rb
@@ -133,7 +133,8 @@ module Refinery
             :de => 'Deutsch',
             :lv => 'Latviski',
             :ru => 'Русский',
-            :sv => 'Svenska'
+            :sv => 'Svenska',
+            :pl => 'Polski'
           },
           {
             :scoping => 'refinery',


### PR DESCRIPTION
A small fix that makes the polish translation selectable in default Refinerycms.
