### PR TITLE
Added current_locale option to initializer.

### DIFF
--- a/lib/generators/refinery/templates/config/initializers/refinery_i18n.rb.erb
+++ b/lib/generators/refinery/templates/config/initializers/refinery_i18n.rb.erb
@@ -3,6 +3,8 @@ Refinery::I18n.configure do |config|
 
   # config.default_locale = :<%= Refinery::I18n.config.default_locale %>
 
+  # config.current_locale = :<%= Refinery::I18n.config.current_locale %>
+
   # config.default_frontend_locale = :<%= Refinery::I18n.config.default_frontend_locale %>
 
   # config.frontend_locales = <%= Refinery::I18n.config.frontend_locales %>


### PR DESCRIPTION
Hello, I have confusing issues using the i18n initializer. If I set my config.default_locale as :es and remove :en in config.frontend_locales and config.locales, I always get the admin dashboard in english when I relaunch the server, and new pages generated by engines have :en locale too.

I'm not sure, but watching configuration.rb in i18n

```
self.default_locale = :en
self.current_locale = self.default_locale
```

So, i think that, if you don´t overwrite current_locale in your refinery i18n initializer, you always get current_locale as :en for the first time you launch the server.

Adding the option in the generator could be less problematic.

Thank you for your great job.
