### PR TITLE
fixes issue with invalid multibyte char on ruby 1.9

### DIFF
--- a/lib/generators/refinery/templates/config/initializers/refinery/i18n.rb.erb
+++ b/lib/generators/refinery/templates/config/initializers/refinery/i18n.rb.erb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 Refinery::I18n.configure do |config|
   # config.enabled = <%= Refinery::I18n.config.enabled.inspect %>
 


### PR DESCRIPTION
Hi folks,
when i have in my installation this configuration:

``` ruby
Refinery::I18n.configure do |config|
  ...
  config.locales = {:en => "English", :cs => "Česky", :sk => "Slovenský"}
end
```

it throws error: `/home/web-data/work/site/config/initializers/refinery/i18n.rb:12: invalid multibyte char (US-ASCII)`
 which can by fixed with this.
This solution i found on http://stackoverflow.com/questions/3678172/ruby-1-9-invalid-multibyte-char-us-ascii
