### PR TITLE
Option for disabling url filter

### DIFF
--- a/lib/refinery/i18n-filter.rb
+++ b/lib/refinery/i18n-filter.rb
@@ -2,7 +2,7 @@ module RoutingFilter
   class RefineryLocales < Filter
 
     def around_recognize(path, env, &block)
-      if ::Refinery::I18n.enabled?
+      if ::Refinery::I18n.url_filter_enabled?
         if path =~ %r{^/(#{::Refinery::I18n.locales.keys.join('|')})(/|$)}
           path.sub! %r(^/(([a-zA-Z\-_])*)(?=/|$)) do
             ::I18n.locale = $1
@@ -24,7 +24,7 @@ module RoutingFilter
 
       yield.tap do |result|
         result = result.is_a?(Array) ? result.first : result
-        if ::Refinery::I18n.enabled? and
+        if ::Refinery::I18n.url_filter_enabled? and
            locale != ::Refinery::I18n.default_frontend_locale and
            result !~ %r{^/(refinery|wymiframe)}
           result.sub!(%r(^(http.?://[^/]*)?(.*))) { "#{$1}/#{locale}#{$2}" }

--- a/lib/refinery/i18n.rb
+++ b/lib/refinery/i18n.rb
@@ -50,6 +50,10 @@ module Refinery
         config.enabled
       end
 
+      def url_filter_enabled?
+        enabled? && config.url_filter_enabled
+      end
+
       def has_locale?(locale)
         config.locales.has_key?(locale.try(:to_sym))
       end

--- a/lib/refinery/i18n/configuration.rb
+++ b/lib/refinery/i18n/configuration.rb
@@ -3,7 +3,8 @@ module Refinery
     include ActiveSupport::Configurable
 
     config_accessor :current_locale, :default_locale, :default_frontend_locale,
-                    :enabled, :fallbacks_enabled, :frontend_locales, :locales
+                    :enabled, :fallbacks_enabled, :frontend_locales, :locales,
+                    :url_filter_enabled
 
     self.enabled = true
     self.default_locale = :en
@@ -12,5 +13,6 @@ module Refinery
     self.fallbacks_enabled = true
     self.frontend_locales = [self.default_frontend_locale]
     self.locales = self.built_in_locales
+    self.url_filter_enabled = true
   end
 end


### PR DESCRIPTION
In our refinery-app, we set the locale based on the subdomain, e.g. `de.foobar.com`. Due to SEO, we would prefer a 404 on `foobar.com/de/contact` (potential duplicate content).

This patch adds a new option, `url_filter_enabled`, that disables only the url filter. Usage:

```
Refinery::I18n.configure do |config|
  # other config ...
  config.url_filter_enabled = false
end
```
