### PR TITLE
Domain Name based i18n

### DIFF
--- a/lib/generators/refinery/templates/config/initializers/refinery/i18n.rb.erb
+++ b/lib/generators/refinery/templates/config/initializers/refinery/i18n.rb.erb
@@ -12,4 +12,8 @@ Refinery::I18n.configure do |config|
   # config.frontend_locales = <%= Refinery::I18n.config.frontend_locales.inspect %>
 
   # config.locales = <%= Refinery::I18n.config.locales.inspect %>
+	
+	# config.domain_name_enabled = <%= Refinery::I18n.config.domain_name_enabled.inspect %>
+	
+	# config.domains_locales = <%= Refinery::I18n.domains_locales.inspect %>
 end

--- a/lib/refinery/i18n-filter.rb
+++ b/lib/refinery/i18n-filter.rb
@@ -2,8 +2,11 @@ module RoutingFilter
   class RefineryLocales < Filter
 
     def around_recognize(path, env, &block)
-      if ::Refinery::I18n.url_filter_enabled?
-        if path =~ %r{^/(#{::Refinery::I18n.locales.keys.join('|')})(/|$)}
+      if ::Refinery::I18n.url_filter_enabled? || ::Refinery::I18n.domain_name_enabled?
+        if ::Refinery::I18n.domain_name_enabled?
+          hostname = env['HTTP_HOST'].sub(/:\d+$/, '')
+          ::I18n.locale = ::Refinery::I18n.domains_locales[hostname] || ::Refinery::I18n.default_frontend_locale
+        elsif path =~ %r{^/(#{::Refinery::I18n.locales.keys.join('|')})(/|$)}
           path.sub! %r(^/(([a-zA-Z\-_])*)(?=/|$)) do
             ::I18n.locale = $1
             ''
@@ -24,7 +27,7 @@ module RoutingFilter
 
       yield.tap do |result|
         result = result.is_a?(Array) ? result.first : result
-        if ::Refinery::I18n.url_filter_enabled? and
+        if ::Refinery::I18n.url_filter_enabled? and !::Refinery::I18n.domain_name_enabled? and
            locale != ::Refinery::I18n.default_frontend_locale and
            result !~ %r{^/(#{Refinery::Core.backend_route}|wymiframe)}
           result.sub!(%r(^(http.?://[^/]*)?(.*))) { "#{$1}/#{locale}#{$2}" }

--- a/lib/refinery/i18n.rb
+++ b/lib/refinery/i18n.rb
@@ -61,6 +61,14 @@ module Refinery
       def has_locale?(locale)
         config.locales.has_key?(locale.try(:to_sym))
       end
+      
+      def domain_name_enabled?
+        config.domain_name_enabled
+      end
+      
+      def domain_name_for_locale(locale)
+        config.domains_locales.invert[locale] || false
+      end
     end
 
     require 'refinery/i18n/engine'

--- a/lib/refinery/i18n/configuration.rb
+++ b/lib/refinery/i18n/configuration.rb
@@ -4,7 +4,7 @@ module Refinery
 
     config_accessor :current_locale, :default_locale, :default_frontend_locale,
                     :enabled, :fallbacks_enabled, :frontend_locales, :locales,
-                    :url_filter_enabled
+                    :url_filter_enabled, :domain_name_enabled, :domains_locales
 
     self.enabled = true
     self.default_locale = :en
@@ -14,5 +14,7 @@ module Refinery
     self.frontend_locales = [self.default_frontend_locale]
     self.locales = self.built_in_locales
     self.url_filter_enabled = true
+    self.domain_name_enabled = false
+    self.domains_locales = {"www.mysite.com"=>:en, "www.mon-site.fr"=>:fr}
   end
 end


### PR DESCRIPTION
have several domain names for the same website because the domain names are localised, allow refinery cms to pick locale base on domain name. 

ex:  www.iam-on-diet.com , www.je-fais-le-regime.fr
