### PR TITLE
Bump rails-i18n version to ~> 4.0.1

### DIFF
--- a/refinerycms-i18n.gemspec
+++ b/refinerycms-i18n.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency    'routing-filter',   '>= 0.4.0.dev'
-  s.add_dependency    'rails-i18n',       '~> 0.7.3'
+  s.add_dependency    'rails-i18n',       '~> 4.0.1'
 end


### PR DESCRIPTION
This change makes it compatible with spree_i18n: https://github.com/spree/spree_i18n/blob/master/spree_i18n.gemspec#L22
