### PR TITLE
Allow strings and symbols in Refinery::I18n#frontend_locales=

### DIFF
--- a/lib/refinery/i18n/configuration.rb
+++ b/lib/refinery/i18n/configuration.rb
@@ -16,7 +16,7 @@ module Refinery
 
     def self.frontend_locales
       config.frontend_locales.select do |locale|
-        config.locales.keys.include?(locale)
+        config.locales.keys.map(&:to_s).include?(locale.to_s)
       end
     end
   end


### PR DESCRIPTION
This is to address refinery/refinerycms#2828

cc @FlowerWrong 