### PR TITLE
Removed last alias_method_chain in engine

### DIFF
--- a/lib/refinery/i18n/engine.rb
+++ b/lib/refinery/i18n/engine.rb
@@ -17,11 +17,10 @@ module Refinery
 
       config.to_prepare do
         ::ApplicationController.module_eval do
-          def default_url_options_with_locale
+          def default_url_options
             locale_param=(::Refinery::I18n.config.enabled? && ::I18n.locale != ::Refinery::I18n.default_frontend_locale) ? { :locale => ::I18n.locale } : {}
-            default_url_options_without_locale.reverse_merge locale_param
+            super.reverse_merge locale_param
           end
-          alias_method_chain :default_url_options, :locale
 
           def find_or_set_locale
             ::I18n.locale = ::Refinery::I18n.current_frontend_locale


### PR DESCRIPTION
Hello @parndt ! 😄 

In this PR I removed the `alias_method_chain` method in `lib/refinery/i18n/engine.rb`, so we don't get any deprecation warnings in the RefineryCMS with rails 5.* by this gem. This is also the only file where the `alias_method_chain` method was used.