### PR TITLE
Replace Globalize by Mobility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-# TODO: Remove this before merging the feature
-git "https://github.com/refinery/refinerycms", branch: "feature/mobility" do
+git "https://github.com/refinery/refinerycms", branch: "master" do
   gem "refinerycms"
 
   group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 
 gemspec
 
-git "https://github.com/refinery/refinerycms", branch: "master" do
+# TODO: Remove this before merging the feature
+git "https://github.com/refinery/refinerycms", branch: "feature/mobility" do
   gem "refinerycms"
 
   group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 if !ENV["TRAVIS"] || ENV["DB"] == "mysql"
   gem "activerecord-jdbcmysql-adapter", :platform => :jruby
   gem "jdbc-mysql", "= 5.1.13", :platform => :jruby
-  gem "mysql2", :platform => :ruby
+  gem 'mysql2', '~> 0.4.10', :platform => :ruby
 end
 
 if !ENV["TRAVIS"] || ENV["DB"] == "postgresql"

--- a/lib/refinery/i18n.rb
+++ b/lib/refinery/i18n.rb
@@ -42,8 +42,8 @@ module Refinery
       end
 
       def current_frontend_locale
-        if Globalize.locale.present? && Globalize.locale.to_s != config.default_frontend_locale.to_s
-          Globalize.locale
+        if Mobility.locale.present? && Mobility.locale.to_s != config.default_frontend_locale.to_s
+          Mobility.locale
         elsif config.default_frontend_locale.present?
           config.default_frontend_locale
         else

--- a/lib/refinery/i18n/engine.rb
+++ b/lib/refinery/i18n/engine.rb
@@ -32,7 +32,7 @@ module Refinery
             else
               ::I18n.locale = ::Refinery::I18n.default_frontend_locale
             end
-            Globalize.locale = ::I18n.locale
+            Mobility.locale = ::I18n.locale
           end
 
           prepend_before_action :find_or_set_locale
@@ -52,11 +52,11 @@ module Refinery
           def globalize!
             if ::Refinery::I18n.frontend_locales.any?
               if params[:switch_locale]
-                Globalize.locale = params[:switch_locale].to_sym
+                Mobility.locale = params[:switch_locale].to_sym
               elsif ::I18n.locale != ::Refinery::I18n.default_frontend_locale
-                Globalize.locale = ::Refinery::I18n.default_frontend_locale
+                Mobility.locale = ::Refinery::I18n.default_frontend_locale
               else
-                Globalize.locale = ::I18n.locale
+                Mobility.locale = ::I18n.locale
               end
             end
           end

--- a/refinerycms-i18n.gemspec
+++ b/refinerycms-i18n.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name              = %q{refinerycms-i18n}
-  s.version           = %q{4.0.2}
+  s.version           = %q{5.0.0}
   s.description       = %q{i18n logic extracted from Refinery CMS, for Refinery CMS.}
   s.summary           = %q{i18n logic for Refinery CMS.}
   s.email             = %q{info@refinerycms.com}

--- a/refinerycms-i18n.gemspec
+++ b/refinerycms-i18n.gemspec
@@ -18,6 +18,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency    'routing-filter',   '>= 0.4.0'
   s.add_dependency    'rails-i18n',       '~> 5.0.0'
-  # TODO: Use `0.6.0` before merging this PR
-  s.add_dependency    'mobility',         '~> 0.5.0'
+  s.add_dependency    'mobility',         '~> 0.6.0'
 end

--- a/refinerycms-i18n.gemspec
+++ b/refinerycms-i18n.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency    'routing-filter',   '>= 0.4.0'
   s.add_dependency    'rails-i18n',       '~> 5.0.0'
+  # TODO: Use `0.6.0` before merging this PR
+  s.add_dependency    'mobility',         '~> 0.5.0'
 end

--- a/spec/controllers/refinery/admin/resources_controller_spec.rb
+++ b/spec/controllers/refinery/admin/resources_controller_spec.rb
@@ -4,30 +4,30 @@ module Refinery
   module Admin
     describe ResourcesController, type: :controller do
       before do
-        Globalize.locale = :en
+        Mobility.locale = :en
         @resource = FactoryBot.create(:resource, :resource_title => "My resource in English")
 
         # Add a translation
-        Globalize.locale = :es
+        Mobility.locale = :es
         @resource.resource_title = 'Mi recurso en español'
         @resource.save
       end
 
-      it 'reset Globalize as expected' do
+      it 'reset Mobility as expected' do
         get :index
-        expect(Globalize.locale).to eql(:en)
+        expect(Mobility.locale).to eql(:en)
         expect(::I18n.locale).to eql(:en)
         expect(assigns(:resources).first.resource_title).to eql('My resource in English')
 
         # Switch globalized content to ES
         get :index, params: { switch_locale: :es }
-        expect(Globalize.locale).to eql(:es)
+        expect(Mobility.locale).to eql(:es)
         expect(::I18n.locale).to eql(:en)
         expect(assigns(:resources).first.resource_title).to eql('Mi recurso en español')
 
         # Should return to default locale for globalized content on next request
         get :index
-        expect(Globalize.locale).to eql(:en)
+        expect(Mobility.locale).to eql(:en)
         expect(::I18n.locale).to eql(:en)
         expect(assigns(:resources).first.resource_title).to eql('My resource in English')
       end


### PR DESCRIPTION
This is a work in progress.

At this time i just want to see if we can quickly move to Mobility.

I would like to remove any Mobility class from this gem and probably create a refinerycms-mobility gem.