### PR TITLE
Bugfix unsupported locale

### DIFF
--- a/lib/refinery/i18n/engine.rb
+++ b/lib/refinery/i18n/engine.rb
@@ -27,7 +27,7 @@ module Refinery
             if ::Refinery::I18n.has_locale?(locale = params[:locale].try(:to_sym))
               ::I18n.locale = locale
             elsif locale.present? && locale != ::Refinery::I18n.default_frontend_locale
-              params[:locale] = ::I18n.locale.to_s = ::Refinery::I18n.default_frontend_locale.to_s
+              params[:locale] = (::I18n.locale = ::Refinery::I18n.default_frontend_locale).to_s
               redirect_to(params, :notice => "The locale '#{locale}' is not supported.") and return
             else
               ::I18n.locale = ::Refinery::I18n.default_frontend_locale


### PR DESCRIPTION
Only `params[:locale]` should be converted to string

This fix https://github.com/refinery/refinerycms/issues/3363