### PR TITLE
Don't reassign params[:locale] if the locale is unsupported

### DIFF
--- a/lib/refinery/i18n/engine.rb
+++ b/lib/refinery/i18n/engine.rb
@@ -27,8 +27,9 @@ module Refinery
             if ::Refinery::I18n.has_locale?(locale = params[:locale].try(:to_sym))
               ::I18n.locale = locale
             elsif locale.present? && locale != ::Refinery::I18n.default_frontend_locale
-              params[:locale] = ::I18n.locale.to_s = ::Refinery::I18n.default_frontend_locale.to_s
-              redirect_to(params, :notice => "The locale '#{locale}' is not supported.") and return
+              ::I18n.locale = ::Refinery::I18n.default_frontend_locale
+              redirect_to(params.permit(:locale).merge(locale: ::I18n.locale),
+                          notice: "The locale '#{locale}' is not supported.") and return
             else
               ::I18n.locale = ::Refinery::I18n.default_frontend_locale
             end

--- a/spec/controllers/refinery/pages_controller_spec.rb
+++ b/spec/controllers/refinery/pages_controller_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+module Refinery
+  describe PagesController, type: :controller do
+    before do
+      FactoryBot.create(:page, title: 'test')
+    end
+
+    context 'when locale is unsupported' do
+      subject { get :show, params: { path: 'test', locale: 'en%20217' } }
+
+      it 'redirects to the location with the default frontend locale' do
+        expect(subject).to redirect_to ('/test')
+      end
+
+      it 'flashes a notice message' do
+        expect(subject.request.flash[:notice]).to eq("The locale 'en%20217' is not supported.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Only fallback to default frontend locale and display a notice

Fixes refinery/refinerycms#3363