### PR TITLE
Add Rails 6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ notifications:
   webhooks:
     - https://webhooks.gitter.im/e/b5d48907cdc89864b874
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
-  - 2.2.10
+  - 2.6.1
+  - 2.5.3
+  - 2.4.5
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+dist: trusty
+sudo: false
 cache: bundler
 bundler_args: --without development
 before_script: "bin/rake refinery:testing:dummy_app"
@@ -12,4 +14,3 @@ rvm:
   - 2.6.1
   - 2.5.3
   - 2.4.5
-sudo: false

--- a/refinerycms-i18n.gemspec
+++ b/refinerycms-i18n.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name              = %q{refinerycms-i18n}
-  s.version           = %q{5.0.0}
+  s.version           = %q{5.0.1}
   s.description       = %q{i18n logic extracted from Refinery CMS, for Refinery CMS.}
   s.summary           = %q{i18n logic for Refinery CMS.}
   s.email             = %q{info@refinerycms.com}
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2.9'
 
   s.add_dependency    'routing-filter',   '~> 0.4'
-  s.add_dependency    'rails-i18n',       '~> 5.0'
-  s.add_dependency    'mobility',         '~> 0.6.0'
+  s.add_dependency    'rails-i18n',       '>= 5.0'
+  s.add_dependency    'mobility',         '~> 0.8.8'
 
   s.cert_chain  = [File.expand_path("../certs/parndt.pem", __FILE__)]
   if $0 =~ /gem\z/ && ARGV.include?("build") && ARGV.include?(__FILE__)


### PR DESCRIPTION
This is to support the work in **refinerycms-core**, see this [pull request](https://github.com/refinery/refinerycms/pull/3441) for the details.

As of right now, if you download [that branch](https://github.com/joebutler2/refinerycms/tree/rails-6-support) and try using it in a fresh Rails 6 application, you'll see the following bundler error:

```
Bundler could not find compatible versions for gem "railties":
  In Gemfile:
    rails (~> 6.0) was resolved to 6.0.0, which depends on
      railties (= 6.0.0)

    refinerycms was resolved to 4.0.2, which depends on
      refinerycms-core (= 4.0.2) was resolved to 4.0.2, which depends on
        refinerycms-i18n (>= 5.0.0, ~> 5.0) was resolved to 5.0.0, which depends on
          rails-i18n (~> 5.0) was resolved to 5.0.4, which depends on
            railties (~> 5.0)
```

Take note of the last 3 lines. Hopefully, with this commit we can start using RefineryCMS on Rails 6 once that other PR is finished & merged in!


--- 

Sidenote: looking at the third to last line `refinerycms-i18n (>= 5.0.0, ~> 5.0)`. Won't the second rule overtake the first one? Since that's in the refinery core gem spec, I'm not sure. I know the bundler rules better than the gemspec rules (not sure if they match exactly either).