### PR TITLE
Use latest version of svenfuchs/routing-filter 

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [parndt, bricesanchez]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        database: [ mysql, postgresql ]
+        ruby: [ 2.7, 2.6 ]
+      fail-fast: false
+      max-parallel: 10
+    runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_JOBS: 4
+      BUNDLE_PATH: vendor/bundle
+      CI: true
+      DB: ${{ matrix.database }}
+      MYSQL_PASSWORD: root
+      PGHOST: localhost
+      PGUSER: postgres
+      RAILS_ENV: test
+
+    name: ${{ matrix.ruby }} ${{ matrix.database }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: sudo apt-get update && sudo apt-get install libpq-dev libmysqlclient-dev libsqlite3-dev -y
+      - run: sudo systemctl start mysql.service
+      - id: cache-bundler
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ matrix.ruby }}-gem-${{ matrix.database }}-${{ hashFiles('Gemfile') }}
+      - run: bundle install --without development --path vendor/bundle
+      - run: bin/rake refinery:testing:dummy_app
+        env:
+          PGPORT: ${{ job.services.postgres.ports[5432] }}
+
+      - run: bin/rspec spec
+        env:
+          PGPORT: ${{ job.services.postgres.ports[5432] }}
+          RETRY_COUNT: 3
+
+    services:
+      postgres:
+        image: postgres:11.5
+        ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ group :development, :test do
   gem "listen"
 end
 
+gem 'routing-filter', git: 'https://github.com/svenfuchs/routing-filter', branch: 'master'
+
 # Database Configuration
 unless ENV["TRAVIS"]
   gem "activerecord-jdbcsqlite3-adapter", :platform => :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 if !ENV["TRAVIS"] || ENV["DB"] == "mysql"
   gem "activerecord-jdbcmysql-adapter", :platform => :jruby
   gem "jdbc-mysql", "= 5.1.13", :platform => :jruby
-  gem 'mysql2', '~> 0.4.10', :platform => :ruby
+  gem 'mysql2', '>= 0.4', :platform => :ruby
 end
 
 if !ENV["TRAVIS"] || ENV["DB"] == "postgresql"

--- a/lib/refinery/i18n-filter.rb
+++ b/lib/refinery/i18n-filter.rb
@@ -27,7 +27,7 @@ module RoutingFilter
         if ::Refinery::I18n.url_filter_enabled? and
            locale != ::Refinery::I18n.default_frontend_locale and
            result !~ %r{^/(#{Refinery::Core.backend_route}|wymiframe)}
-          result.sub!(%r(^(http.?://[^/]*)?(.*))) { "#{$1}/#{locale}#{$2}" }
+          result.url.sub!(%r(^(http.?://[^/]*)?(.*))) { "#{$1}/#{locale}#{$2}" }
         end
       end
     end

--- a/refinerycms-i18n.gemspec
+++ b/refinerycms-i18n.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.9'
 
-  s.add_dependency    'routing-filter',   '~> 0.4'
+  s.add_dependency    'routing-filter',   '~> 0.6.3'
   s.add_dependency    'rails-i18n',       '>= 5.0'
   s.add_dependency    'mobility',         '~> 0.8.8'
 

--- a/spec/support/refinery/refinery_login.rb
+++ b/spec/support/refinery/refinery_login.rb
@@ -1,0 +1,3 @@
+def refinery_login
+  let(:logged_in_user) { Refinery::Core::NilUser.new }
+end


### PR DESCRIPTION
to handle changes to rails routing internals.

1. Update version of routing-filter in .gemspec
2. No new version number for routing-filter, so add explicit call to master in Gemfile.
3. Change handling as RoutingFilter is now an object 
```
#<RoutingFilter::ResultWrapper:0x00007fb810f3e3a8 @url="/test", @params={:_recall=>{}}>
```

Test passed before pushing here, although I think they have just failed on the Github testing.