### PR TITLE
Bugfix: Return the result

### DIFF
--- a/lib/refinery/i18n-filter.rb
+++ b/lib/refinery/i18n-filter.rb
@@ -26,8 +26,8 @@ module RoutingFilter
         result = result.is_a?(Array) ? result.first : result
         if ::Refinery::I18n.url_filter_enabled? and
            locale != ::Refinery::I18n.default_frontend_locale and
-           result !~ %r{^/(#{Refinery::Core.backend_route}|wymiframe)}
-          result.url.sub!(%r(^(http.?://[^/]*)?(.*))) { "#{$1}/#{locale}#{$2}" }
+           result.url !~ %r{^/(#{Refinery::Core.backend_route}|wymiframe)}
+          result.return(result.url.sub(%r(^(http.?://[^/]*)?(.*))) { "#{$1}/#{locale}#{$2}" })
         end
       end
     end


### PR DESCRIPTION
In routing-filter version 0.7 for Rails 6.1 it requires that you explicitly return the result

Signed-off-by: Tim Chambers <tim@hint.io>